### PR TITLE
[Instagram] Change regex to match URLs without trailing slash

### DIFF
--- a/cogs/Instagram.py
+++ b/cogs/Instagram.py
@@ -139,7 +139,7 @@ class IGPostResult:
 
 
 class Instagram(commands.Cog):
-    URL_REGEX = r"https?://(www.)?instagram.com/(.*)?(p|tv|reel)/(.*?)/"
+    URL_REGEX = r"https?://(www\.)?instagram\.com/(p|tv|reel)/([a-zA-Z0-9]*)"
     FILESIZE_MIN = 10 ** 3
     FILESIZE_MAX = 8 * 10 ** 6  # 8 MB
     MAX_RETRIES = 3


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6728859/160413143-20c5aecf-7ac5-4eaf-85f8-e153f49ea588.png)
